### PR TITLE
v1.1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,14 @@
 
 [Dynomite](https://github.com/Netflix/dynomite) seed management / seed_provider.
 
-dynomite-floridalist works as Dynomite `seed_provider` using same communicate as Florida.
+dynomite-floridalist works as Dynomite `seed_provider` using same communicate as Florida API.
 
 features below:
 
+- Automated seed_provider / less state dependence
 - Simple configuration management. `dynomite-florialist` can using `dynomite.yml`
-- Container friendly. `dynomite-floridalist` can be applied to both sidecar patterns and centralized pattern
-- `dynomite.yml` generator
+- Container friendly. `dynomite-floridalist` can be applied to both sidecar pattern and centralized pattern
+- Consistently generate `dynomite.yml` and using it
 - Clustering and node management with [memberlist](https://github.com/hashicorp/memberlist)
 
 ## Build
@@ -50,10 +51,11 @@ USAGE:
    dynomite-floridalist [global options] command [command options] [arguments...]
 
 VERSION:
-   1.1.0
+   1.1.3
 
 COMMANDS:
-     help, h  Shows a list of commands or help for one command
+     generate  generate `dynomite.yml`
+     help, h   Shows a list of commands or help for one command
 
 GLOBAL OPTIONS:
    --join value, -j value       join memberlist cluster address (default: "127.0.0.1:3101") [$DYN_FLORIDALIST_JOIN_ADDR]
@@ -71,6 +73,7 @@ GLOBAL OPTIONS:
    --http-read-timeout value    florida API read timeout (default: "500ms")
    --http-write-timeout value   florida API write timeout (default: "500ms")
    --ml-leave-timeout value     memberlist cluster leave timeout (default: "30s")
+   --wan                        use WANconfig (defaults LANConfig)
    --procs value, -P value      attach cpu(s) (default: 8)
    --debug, -d                  debug mode
    --verbose, -V                verbose. more message
@@ -124,9 +127,10 @@ $ DYN_DC="ap-northeast-1"
 $ DYN_RACK="ap-northeast-1d"
 $ DYN_TOKEN="0"
 $ DYN_BACKEND_SERVER="127.0.0.1:6379:100"
+$ DYNOMITE_YAML="/etc/dynomite.yml"
 
 # run. same source
-$ dynomite-floridalist generate -o /etc/dynomite.yml
-$ dynomite-floridalist -c /etc/dynomite.yml
-$ dynomite -c /etc/dynomite.yml
+$ dynomite-floridalist generate -o $DYNOMITE_YAML
+$ dynomite-floridalist -c $DYNOMITE_YAML
+$ dynomite -c $DYNOMITE_YAML
 ```

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -137,6 +137,7 @@ func action(c *cli.Context) error {
     HttpReadTimeout:        httpReadTimeout,
     HttpWriteTimeout:       httpWriteTimeout,
     MemberlistLeaveTimeout: leaveTimeout,
+    UseWANConfig:           c.Bool("wan"),
   }
   if config.Procs < 1 {
     config.Procs = 1
@@ -317,6 +318,10 @@ func main(){
       Name: "ml-leave-timeout",
       Usage: "memberlist cluster leave timeout",
       Value: floridalist.DEFAULT_MEMBERLIST_LEAVE_TIMEOUT,
+    },
+    cli.BoolFlag{
+      Name: "wan",
+      Usage: "use WANconfig (defaults LANConfig)",
     },
     cli.IntFlag{
       Name: "procs, P",

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -108,7 +108,7 @@ func action(c *cli.Context) error {
   if adv.Datacenter == "" || adv.Rack == "" || adv.Token == "" || adv.Address == "" {
     msg := fmt.Sprintf(
       `
-      error: seed Advertise includes empty value.
+      error: seed Advertise doesnt include empty value.
       Datacenter: '%s'
       Rack: '%s'
       Token: '%s'
@@ -119,7 +119,6 @@ func action(c *cli.Context) error {
       adv.Token,
       adv.Address,
     )
-    log.Printf("error: %s", msg)
     return fmt.Errorf(msg)
   }
 

--- a/config.go
+++ b/config.go
@@ -20,6 +20,8 @@ type Config struct {
   HttpReadTimeout        time.Duration
   HttpWriteTimeout       time.Duration
   MemberlistLeaveTimeout time.Duration
+
+  UseWANConfig           bool
 }
 
 type SeedAdvertise struct {

--- a/member.go
+++ b/member.go
@@ -62,7 +62,7 @@ func NewMemberlistConfig(ctx context.Context) *memberlist.Config {
     name = fmt.Sprintf("%s:%d", config.MemberlistBindIp, config.MemberlistBindPort)
   }
 
-  c                  := memberlist.DefaultLANConfig()
+  c                  := createMemberlistConfig(config)
   c.Name              = name
   c.BindAddr          = config.MemberlistBindIp
   c.BindPort          = config.MemberlistBindPort
@@ -71,6 +71,12 @@ func NewMemberlistConfig(ctx context.Context) *memberlist.Config {
   c.Logger            = logger.NewLogger()
 
   return c
+}
+func createMemberlistConfig(config Config) *memberlist.Config {
+  if config.UseWANConfig {
+    return memberlist.DefaultWANConfig()
+  }
+  return memberlist.DefaultLANConfig()
 }
 
 type Member struct {

--- a/version.go
+++ b/version.go
@@ -2,6 +2,6 @@ package floridalist
 
 const (
   AppName string = "dynomite-floridalist"
-  Version string = "1.1.2"
+  Version string = "1.1.3"
   UA      string = AppName + "/" + Version
 )


### PR DESCRIPTION
- add `--wan` to use Memberlist [DefaultWANConfig](https://godoc.org/github.com/hashicorp/memberlist#DefaultWANConfig)
- add SIGCONT signal handling, dump seedlist to standard output